### PR TITLE
Add cancelable SQL api requests

### DIFF
--- a/template/src/components/common/Isochrone.js
+++ b/template/src/components/common/Isochrone.js
@@ -88,15 +88,23 @@ export function Isochrone(props) {
   }, [dispatch]);
 
   useEffect(() => {
+    const abortController = new AbortController();
+
     const handleCalculateIsochrone = async () => {
       try {
-        const isochrone = await getIsochrone(credentials, {
-          geom: latLong,
-          mode: selectedMode,
-          range: selectedRange,
-        });
+        const isochrone = await getIsochrone(
+          credentials,
+          {
+            geom: latLong,
+            mode: selectedMode,
+            range: selectedRange,
+          },
+          { abortController }
+        );
         updateIsochrone(isochrone);
       } catch (error) {
+        if (error.name === 'AbortError') return;
+
         dispatch(setError(`Isochrone error: ${error.message}`));
       }
     };
@@ -104,6 +112,10 @@ export function Isochrone(props) {
     if (openIsochroneConfig && selectedMode && selectedRange) {
       handleCalculateIsochrone();
     }
+
+    return function cleanup() {
+      abortController.abort();
+    };
   }, [
     dispatch,
     updateIsochrone,

--- a/template/src/components/common/Isochrone.js
+++ b/template/src/components/common/Isochrone.js
@@ -92,15 +92,13 @@ export function Isochrone(props) {
 
     const handleCalculateIsochrone = async () => {
       try {
-        const isochrone = await getIsochrone(
+        const isochrone = await getIsochrone({
           credentials,
-          {
-            geom: latLong,
-            mode: selectedMode,
-            range: selectedRange,
-          },
-          { abortController }
-        );
+          geom: latLong,
+          mode: selectedMode,
+          range: selectedRange,
+          opts: { abortController },
+        });
         updateIsochrone(isochrone);
       } catch (error) {
         if (error.name === 'AbortError') return;

--- a/template/src/components/views/datasets/Datasets.js
+++ b/template/src/components/views/datasets/Datasets.js
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 // Limit the number of datasets, using just 1 page, up to 50 datasets
-const datasetsPagination = { page: 1, size: 50 };
+const pagination = { page: 1, size: 50 };
 
 function Datasets() {
   const credentials = useSelector(selectOAuthCredentials);
@@ -31,7 +31,7 @@ function Datasets() {
     if (credentials) {
       // Get user datasets, once logged in
       setLoading(true);
-      getUserDatasets(credentials, { datasetsPagination, abortController })
+      getUserDatasets(credentials, { pagination, abortController })
         .then((datasets) => {
           setDatasets(datasets);
           setLoading(false);

--- a/template/src/lib/api/Geocoding.js
+++ b/template/src/lib/api/Geocoding.js
@@ -11,7 +11,8 @@ import { executeSQL } from './SQL';
  */
 export const geocodeStreetPoint = async (
   credentials,
-  { searchText, city, state, country }
+  { searchText, city, state, country },
+  opts = {}
 ) => {
   if (credentials.apiKey === 'default_public') {
     throw new Error('To search a location you need to login or provide an API KEY');
@@ -20,7 +21,7 @@ export const geocodeStreetPoint = async (
   const query = `SELECT ST_AsGeoJSON(cdb_geocode_street_point('${searchText}', '${
     city ?? ''
   }', '${state ?? ''}', '${country ?? ''}')) AS geometry`;
-  const results = await executeSQL(credentials, query);
+  const results = await executeSQL(credentials, query, opts);
 
   const geometry = JSON.parse(results[0].geometry);
   if (geometry === null) return null;

--- a/template/src/lib/utils/requestsUtils.js
+++ b/template/src/lib/utils/requestsUtils.js
@@ -6,19 +6,20 @@ export const REQUEST_GET_MAX_URL_LENGTH = 2048;
 /**
  * Simple GET request
  */
-export function getRequest(url) {
+export function getRequest(url, opts) {
   return new Request(url, {
     method: 'GET',
     headers: {
       Accept: 'application/json',
     },
+    ...opts,
   });
 }
 
 /**
  * Simple POST request
  */
-export function postRequest(url, payload) {
+export function postRequest(url, payload, opts) {
   return new Request(url, {
     method: 'POST',
     headers: {
@@ -26,6 +27,7 @@ export function postRequest(url, payload) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(payload),
+    ...opts,
   });
 }
 

--- a/template/src/lib/widgets/FormulaWidget.js
+++ b/template/src/lib/widgets/FormulaWidget.js
@@ -1,31 +1,51 @@
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
-import { selectSourceById } from 'config/cartoSlice';
+import { useSelector, useDispatch } from 'react-redux';
+import { selectSourceById, setError } from 'config/cartoSlice';
 import { WrapperWidgetUI, FormulaWidgetUI } from 'lib/ui';
 import { getFormula } from './models/FormulaModel';
 
 export default function FormulaWidget(props) {
   const [formulaData, setFormulaData] = useState(null);
   const [loading, setLoading] = useState(false);
+  const dispatch = useDispatch();
   const viewport = useSelector((state) => props.viewportFilter && state.carto.viewport);
   const source = useSelector((state) => selectSourceById(state, props.dataSource) || {});
   const { data, credentials, filters } = source;
 
   useEffect(() => {
+    const abortController = new AbortController();
+
     if (
       data &&
       credentials &&
       (!props.viewportFilter || (props.viewportFilter && viewport))
     ) {
       setLoading(true);
-      getFormula({ ...props, data, filters, credentials, viewport }).then((data) => {
-        data && data[0] && setFormulaData(data[0].value);
-        setLoading(false);
-      });
+      getFormula({
+        ...props,
+        data,
+        filters,
+        credentials,
+        viewport,
+        opts: { abortController },
+      })
+        .then((data) => {
+          data && data[0] && setFormulaData(data[0].value);
+          setLoading(false);
+        })
+        .catch((error) => {
+          if (error.name === 'AbortError') return;
+
+          dispatch(setError(`Formula widget error: ${error.message}`));
+        });
     } else {
       setFormulaData(undefined);
     }
-  }, [credentials, data, filters, viewport, props]);
+
+    return function cleanup() {
+      abortController.abort();
+    };
+  }, [credentials, data, filters, viewport, props, dispatch]);
 
   return (
     <WrapperWidgetUI title={props.title} expandable={true} loading={loading}>

--- a/template/src/lib/widgets/models/CategoryModel.js
+++ b/template/src/lib/widgets/models/CategoryModel.js
@@ -1,7 +1,7 @@
 import { executeSQL, filtersToSQL, viewportToSQL } from '../../api';
 
 export const getCategories = async (props) => {
-  const { data, credentials, column, operation, filters, viewport } = props;
+  const { data, credentials, column, operation, filters, viewport, opts } = props;
 
   const operationColumn = props.operationColumn || column;
 
@@ -28,5 +28,5 @@ export const getCategories = async (props) => {
     FROM all_categories a
     LEFT JOIN categories b ON a.category=b.category`;
 
-  return await executeSQL(credentials, query);
+  return await executeSQL(credentials, query, opts);
 };

--- a/template/src/lib/widgets/models/FormulaModel.js
+++ b/template/src/lib/widgets/models/FormulaModel.js
@@ -1,7 +1,7 @@
 import { executeSQL, filtersToSQL, viewportToSQL } from '../../api';
 
 export const getFormula = async (props) => {
-  const { data, credentials, operation, column, filters, viewport } = props;
+  const { data, credentials, operation, column, filters, viewport, opts } = props;
 
   if (Array.isArray(data)) {
     throw new Error('Array is not a valid type to get categories');
@@ -17,5 +17,5 @@ export const getFormula = async (props) => {
     ${filtersToSQL(filters)}
   `;
 
-  return await executeSQL(credentials, query);
+  return await executeSQL(credentials, query, opts);
 };

--- a/template/src/lib/widgets/models/HistogramModel.js
+++ b/template/src/lib/widgets/models/HistogramModel.js
@@ -1,7 +1,7 @@
 import { executeSQL, filtersToSQL, viewportToSQL } from '../../api';
 
 export const getHistogram = async (props) => {
-  const { data, credentials, column, operation, ticks, filters, viewport } = props;
+  const { data, credentials, column, operation, ticks, filters, viewport, opts } = props;
 
   const operationColumn = props.operationColumn || column;
 
@@ -25,7 +25,7 @@ export const getHistogram = async (props) => {
       ) as q
     GROUP BY tick`;
 
-  const queryResult = await executeSQL(credentials, query);
+  const queryResult = await executeSQL(credentials, query, opts);
   const result = [];
 
   for (let i = 0; i <= ticks.length; i++) {

--- a/template/src/models/IsochroneModel.js
+++ b/template/src/models/IsochroneModel.js
@@ -13,10 +13,13 @@ export const RANGES = {
   THIRTY: 30,
 };
 
-export const getIsochrone = async (
+export const getIsochrone = async ({
   credentials,
-  { geom, mode = MODES.WALK, range = RANGES.TEN }
-) => {
+  geom,
+  mode = MODES.WALK,
+  range = RANGES.TEN,
+  opts = {},
+}) => {
   if (credentials.apiKey === 'default_public') {
     throw new Error('To calculate isochrones you need to login or provide an API KEY');
   }
@@ -24,5 +27,7 @@ export const getIsochrone = async (
   const query = `SELECT q.the_geom from cdb_isochrone(ST_SetSRID(ST_MakePoint(${
     geom[1]
   }, ${geom[0]}),4326), '${mode}', ARRAY[${range * 60}]) q`;
-  return await executeSQL(credentials, query, { format: 'geojson' });
+
+  opts.format = 'geojson';
+  return await executeSQL(credentials, query, opts);
 };

--- a/template/src/models/StoreModel.js
+++ b/template/src/models/StoreModel.js
@@ -1,16 +1,16 @@
 import { executeSQL } from 'lib';
 
-export const getStore = async ({ id, credentials }) => {
+export const getStore = async ({ id, credentials, opts }) => {
   const query = `
     SELECT address, city, phone, revenue, storetype, zip, ST_X(the_geom) as longitude, ST_Y(the_geom) as latitude
       FROM mcdonalds 
       WHERE store_id='${id}'
   `;
 
-  return await executeSQL(credentials, query).then((data) => data[0]);
+  return await executeSQL(credentials, query, opts).then((data) => data[0]);
 };
 
-export const getRevenuePerMonth = async ({ id, credentials }) => {
+export const getRevenuePerMonth = async ({ id, credentials, opts }) => {
   const query = `
       SELECT revenue, date, 
           (
@@ -21,5 +21,5 @@ export const getRevenuePerMonth = async ({ id, credentials }) => {
         FROM mcdonalds_revenue
         WHERE store_id='${id}'
   `;
-  return await executeSQL(credentials, query);
+  return await executeSQL(credentials, query, opts);
 };


### PR DESCRIPTION
Add cancelable mechanism to SQL api / datasets fetch requests + its application to:

- [x] Formula widget
- [x] Category widget
- [x] Histogram widget
- [x] Geocoding
- [x] Isochrone
- [x] User datasets

Allow the use of signal & AbortController to abort fetch requests, so they are correctly cleaned up in react components, and they don't throw errors on console like this one:
![image](https://user-images.githubusercontent.com/458196/99081947-d1953880-25c3-11eb-9ed9-a3753aaf249c.png)


This adds cleanup functions to each component.