### PR TITLE
Manage errors from views, using onError in widgets

### DIFF
--- a/template/src/components/views/Kpi.js
+++ b/template/src/components/views/Kpi.js
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { setError } from 'config/appSlice';
+
 import { Divider } from '@material-ui/core';
 import { AggregationTypes, CategoryWidget, FormulaWidget } from 'lib';
 import {
@@ -50,6 +52,14 @@ export default function Kpi() {
     };
   }, [dispatch]);
 
+  const onTotalRevenueWidgetError = (error) => {
+    dispatch(setError(`Error obtaining total revenue: ${error.message}`));
+  };
+
+  const onRevenueByStateWidgetError = (error) => {
+    dispatch(setError(`Error obtaining revenue by state: ${error.message}`));
+  };
+
   return (
     <div>
       <FormulaWidget
@@ -59,6 +69,7 @@ export default function Kpi() {
         operation={AggregationTypes.SUM}
         formatter={currencyFormatter}
         viewportFilter
+        onError={onTotalRevenueWidgetError}
       ></FormulaWidget>
       <Divider />
       <CategoryWidget
@@ -69,6 +80,7 @@ export default function Kpi() {
         operation={AggregationTypes.SUM}
         formatter={currencyFormatter}
         viewportFilter
+        onError={onRevenueByStateWidgetError}
       />
     </div>
   );

--- a/template/src/components/views/stores/StoresDetail.js
+++ b/template/src/components/views/stores/StoresDetail.js
@@ -87,6 +87,14 @@ export default function StoresDetail() {
     );
   }
 
+  const onTotalRevenueWidgetError = (error) => {
+    dispatch(setError(`Error obtaining total revenue: ${error.message}`));
+  };
+
+  const onRevenuePerMonthWidgetError = (error) => {
+    dispatch(setError(`Error obtaining revenue per month: ${error.message}`));
+  };
+
   return (
     <div>
       <IconButton onClick={() => navigate('/stores')} className={classes.closeDetail}>
@@ -113,7 +121,11 @@ export default function StoresDetail() {
       <Divider />
 
       <WrapperWidgetUI title='Total revenue'>
-        <FormulaWidgetUI formatter={currencyFormatter} data={storeDetail.revenue} />
+        <FormulaWidgetUI
+          formatter={currencyFormatter}
+          data={storeDetail.revenue}
+          onError={onTotalRevenueWidgetError}
+        />
       </WrapperWidgetUI>
 
       <Divider />
@@ -125,6 +137,7 @@ export default function StoresDetail() {
           dataAxis={MONTHS_LABELS}
           yAxisFormatter={currencyFormatter}
           tooltipFormatter={tooltipFormatter}
+          onError={onRevenuePerMonthWidgetError}
         ></HistogramWidgetUI>
       </WrapperWidgetUI>
     </div>

--- a/template/src/components/views/stores/StoresList.js
+++ b/template/src/components/views/stores/StoresList.js
@@ -1,10 +1,27 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import { setError } from 'config/appSlice';
+
 import Divider from '@material-ui/core/Divider';
 import { AggregationTypes, FormulaWidget, CategoryWidget, HistogramWidget } from 'lib';
 import { SOURCE_ID } from './constants';
 import { currencyFormatter, numberFormatter } from 'utils/formatter';
 
 export default function StoresList() {
+  const dispatch = useDispatch();
+
+  const onTotalRevenueWidgetError = (error) => {
+    dispatch(setError(`Error obtaining total revenue: ${error.message}`));
+  };
+
+  const onRevenuePerTypeWidgetError = (error) => {
+    dispatch(setError(`Error obtaining revenue per type: ${error.message}`));
+  };
+
+  const onStoresByRevenueWidgetError = (error) => {
+    dispatch(setError(`Error obtaining stores per revenue: ${error.message}`));
+  };
+
   return (
     <div>
       <FormulaWidget
@@ -14,6 +31,7 @@ export default function StoresList() {
         operation={AggregationTypes.SUM}
         formatter={currencyFormatter}
         viewportFilter
+        onError={onTotalRevenueWidgetError}
       ></FormulaWidget>
 
       <Divider />
@@ -27,6 +45,7 @@ export default function StoresList() {
         operation={AggregationTypes.SUM}
         formatter={currencyFormatter}
         viewportFilter
+        onError={onRevenuePerTypeWidgetError}
       />
 
       <Divider />
@@ -41,6 +60,7 @@ export default function StoresList() {
         column='revenue'
         ticks={[1200000, 1300000, 1400000, 1500000, 1600000, 1700000, 1800000]}
         viewportFilter
+        onError={onStoresByRevenueWidgetError}
       ></HistogramWidget>
     </div>
   );

--- a/template/src/lib/widgets/CategoryWidget.js
+++ b/template/src/lib/widgets/CategoryWidget.js
@@ -3,7 +3,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { addFilter, removeFilter, selectSourceById } from 'lib/slice/cartoSlice';
 import { WrapperWidgetUI, CategoryWidgetUI } from 'lib/ui';
 import { FilterTypes, getApplicableFilters } from 'lib/api';
-import { setError } from 'config/appSlice';
 import { getCategories } from './models';
 
 export default function CategoryWidget(props) {
@@ -39,8 +38,7 @@ export default function CategoryWidget(props) {
         })
         .catch((error) => {
           if (error.name === 'AbortError') return;
-
-          dispatch(setError(`Category widget error: ${error.message}`));
+          if (props.onError) props.onError(error);
         });
     } else {
       setCategoryData(null);

--- a/template/src/lib/widgets/FormulaWidget.js
+++ b/template/src/lib/widgets/FormulaWidget.js
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectSourceById } from 'lib/slice/cartoSlice';
 import { WrapperWidgetUI, FormulaWidgetUI } from 'lib/ui';
 import { getFormula } from './models';
-import { setError } from 'config/appSlice';
 
 export default function FormulaWidget(props) {
   const [formulaData, setFormulaData] = useState(null);
@@ -36,8 +35,7 @@ export default function FormulaWidget(props) {
         })
         .catch((error) => {
           if (error.name === 'AbortError') return;
-
-          dispatch(setError(`Formula widget error: ${error.message}`));
+          if (props.onError) props.onError(error);
         });
     } else {
       setFormulaData(undefined);

--- a/template/src/lib/widgets/HistogramWidget.js
+++ b/template/src/lib/widgets/HistogramWidget.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { addFilter, removeFilter, selectSourceById } from 'lib/slice/cartoSlice';
 import { WrapperWidgetUI, HistogramWidgetUI } from 'lib/ui';
-import { setError } from 'config/appSlice';
 import { FilterTypes, getApplicableFilters } from 'lib/api';
 import { getHistogram } from './models';
 
@@ -49,8 +48,7 @@ export default function HistogramWidget(props) {
         .then((data) => data && setHistogramData(data))
         .catch((error) => {
           if (error.name === 'AbortError') return;
-
-          dispatch(setError(`Histogram widget error: ${error.message}`));
+          if (props.onError) props.onError(error);
         });
     } else {
       setHistogramData([]);


### PR DESCRIPTION
This allows decoupling widgets from setError (currently in the app), so it is required to split the lib